### PR TITLE
Fix locale-sensitive post_mod coordinate parsing

### DIFF
--- a/libs/post_mod/bin/mod_post
+++ b/libs/post_mod/bin/mod_post
@@ -632,16 +632,16 @@ else # $1 == --mode
 			# we use scale=\modDGHyperScale=3, so divide the max
 			maxDimen=190
 		fi
-		grep "^graph" $fileNoExt.plain | awk -v maxDimen=$maxDimen '{if($3 > maxDimen || $4 > maxDimen) {exit 1} else {exit 0}}'
+		grep "^graph" $fileNoExt.plain | LC_ALL=C awk -v maxDimen=$maxDimen '{if($3 + 0 > maxDimen || $4 + 0 > maxDimen) {exit 1} else {exit 0}}'
 		if test $? -ne 0; then
-			width=$(grep "^graph" $fileNoExt.plain | awk '{print $3}')
-			height=$(grep "^graph" $fileNoExt.plain | awk '{print $4}')
+			width=$(grep "^graph" $fileNoExt.plain | LC_ALL=C awk '{print $3}')
+			height=$(grep "^graph" $fileNoExt.plain | LC_ALL=C awk '{print $4}')
 			#echo "Dimension of $fileNoExt ($width, $height) too large for Latex, default to Graphviz."
 			echo "$dimensionTooLargeString" >> $coordFile.$$
 			local gvArgs="-Tpdf ${!gvArgsVar} -o ${fileNoExt}_coord.pdf"
 			dot $gvArgs $fileNoExt.dot
 		fi
-		cat $fileNoExt.plain | awk -v noOverlay="x$noOverlay" -v idOffset=$idOffset '
+		cat $fileNoExt.plain | LC_ALL=C awk -v noOverlay="x$noOverlay" -v idOffset=$idOffset '
 function abs(a) {
 	return a < 0 ? -a : a
 }


### PR DESCRIPTION
## Summary

Fix PostMØD's Graphviz `.plain` parsing so coordinate dimensions are interpreted with the C locale.

Under locales such as `de_DE.UTF-8`, the size check for Graphviz output can misclassify small figures as too large. For example, a graph line like `graph 1 3.1224 3.2197` can trigger the `\dontUseTooLargeCoords` fallback, causing summaries to show `Figure too large` even though the DG is small enough to embed.

This change runs the relevant `awk` parsers with `LC_ALL=C` while leaving the surrounding environment unchanged.

## Validation

Locally reproduced the false fallback under `LC_ALL=de_DE.UTF-8` with a small derivation graph, then verified the patched `mod_post` no longer emits `\dontUseTooLargeCoords` and the summary embeds the DG correctly under both `de_DE.UTF-8` and `C.UTF-8`.